### PR TITLE
feat: report stats to stats.vana.org

### DIFF
--- a/.env.mainnet.example
+++ b/.env.mainnet.example
@@ -162,7 +162,7 @@ PRYSM_BLOB_BATCH_LIMIT_BURST_FACTOR=8     # Set this to   8 for a full node,  2 
 TRUSTED_BEACON_NODE_URL=https://rpc.vana.org
 WEAK_SUBJECTIVITY_CHECKPOINT=0x0000000000000000000000000000000000000000000000000000000000000000:0  # block root:epoch number
 
-# Report stats to the public stats server
+# Report stats to the public stats service
 STATS_SERVER_URL=https://stats.vana.org
 INSTANCE_NAME="Example Validator"
 VALIDATOR_PUBLIC_KEY= # The public key of your validator, e.g. 0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000

--- a/.env.mainnet.example
+++ b/.env.mainnet.example
@@ -162,7 +162,9 @@ PRYSM_BLOB_BATCH_LIMIT_BURST_FACTOR=8     # Set this to   8 for a full node,  2 
 TRUSTED_BEACON_NODE_URL=https://rpc.vana.org
 WEAK_SUBJECTIVITY_CHECKPOINT=0x0000000000000000000000000000000000000000000000000000000000000000:0  # block root:epoch number
 
-# Report stats to the public stats service
-STATS_SERVER_URL=https://stats.vana.org
-INSTANCE_NAME="Example Validator"
-VALIDATOR_PUBLIC_KEY= # The public key of your validator, e.g. 0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+# Report stats to the Vana stats service
+STATS_SERVICE_URL=https://stats.vana.org
+STATS_API_KEY= # Your API key for the stats service, if you have one
+NODE_NAME="Example Node" # A user-friendly name for your node
+VALIDATOR_PUBLIC_KEYS= # The public keys of all validators running on this node, e.g. 0x123...,0x456...,0x789...
+STATS_LOG_LEVEL=info # The log level for the stats service, e.g. "info", "debug", "error", "warn"

--- a/container-scripts/check-config.sh
+++ b/container-scripts/check-config.sh
@@ -23,6 +23,46 @@ if [ ! -f /vana/data/jwt.hex ]; then
 fi
 
 echo "JWT secret check passed"
+
+# Check stats-related configuration
+if [ -z "$STATS_SERVICE_URL" ]; then
+  echo "Error: STATS_SERVICE_URL is not set."
+  echo "Please set the stats service URL in your .env file."
+  exit 1
+fi
+
+echo "STATS_SERVICE_URL check passed"
+
+# Check NODE_NAME
+if [ -z "$NODE_NAME" ] || [ "$NODE_NAME" = "Example Node" ]; then
+  echo "Error: NODE_NAME is not set or is still the default value."
+  echo "Please set a unique node name in your .env file."
+  exit 1
+fi
+
+echo "NODE_NAME check passed"
+
+# Check STATS_API_KEY if provided
+if [ -n "$STATS_API_KEY" ]; then
+  echo "STATS_API_KEY check passed"
+else
+  echo "Note: STATS_API_KEY is not set. Stats will be reported anonymously."
+fi
+
+# Check STATS_LOG_LEVEL
+if [ -n "$STATS_LOG_LEVEL" ]; then
+  case "$STATS_LOG_LEVEL" in
+    info|debug|error|warn) ;;
+    *)
+      echo "Error: Invalid STATS_LOG_LEVEL '$STATS_LOG_LEVEL'. Must be one of: info, debug, error, warn"
+      exit 1
+      ;;
+  esac
+  echo "STATS_LOG_LEVEL check passed"
+else
+  echo "Note: STATS_LOG_LEVEL not set, defaulting to 'info'"
+fi
+
 # Check if we need to perform validator-related checks
 if [ "$USE_VALIDATOR" = "true" ]; then
   echo "Performing validator-specific checks..."
@@ -80,23 +120,14 @@ if [ "$USE_VALIDATOR" = "true" ]; then
 
   echo "DEPOSIT_CONTRACT_ADDRESS check passed"
 
-  # Check VALIDATOR_PUBLIC_KEY
-  if [ -z "$VALIDATOR_PUBLIC_KEY" ] || [ "$VALIDATOR_PUBLIC_KEY" = "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" ]; then
-    echo "Error: VALIDATOR_PUBLIC_KEY is not set or is still the default value."
-    echo "Please set a valid validator public key in your .env file."
+  # Check VALIDATOR_PUBLIC_KEYS
+  if [ -z "$VALIDATOR_PUBLIC_KEYS" ] || [ "$VALIDATOR_PUBLIC_KEYS" = "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" ]; then
+    echo "Error: VALIDATOR_PUBLIC_KEYS is not set or is still the default value."
+    echo "Please set valid validator public keys in your .env file."
     exit 1
   fi
 
-  echo "VALIDATOR_PUBLIC_KEY check passed"
-
-  # Check INSTANCE_NAME
-  if [ -z "$INSTANCE_NAME" ] || [ "$INSTANCE_NAME" = "Example Validator" ]; then
-    echo "Error: INSTANCE_NAME is not set or is still the default value."
-    echo "Please set a unique instance name in your .env file."
-    exit 1
-  fi
-
-  echo "INSTANCE_NAME check passed"
+  echo "VALIDATOR_PUBLIC_KEYS check passed"
 else
   echo "Skipping validator-specific checks..."
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,8 +108,11 @@ services:
       - DEPOSIT_RPC_URL
       - DEPOSIT_CONTRACT_ADDRESS
       - USE_VALIDATOR=true
-      - INSTANCE_NAME
-      - VALIDATOR_PUBLIC_KEY
+      - NODE_NAME
+      - VALIDATOR_PUBLIC_KEYS
+      - STATS_SERVICE_URL
+      - STATS_API_KEY
+      - STATS_LOG_LEVEL
     command: /vana/container-scripts/check-config.sh
     depends_on:
       geth-init:
@@ -135,6 +138,10 @@ services:
     environment:
       - NETWORK
       - USE_VALIDATOR=false
+      - NODE_NAME
+      - STATS_SERVICE_URL
+      - STATS_API_KEY
+      - STATS_LOG_LEVEL
     command: /vana/container-scripts/check-config.sh
     depends_on:
       geth-init:
@@ -627,17 +634,18 @@ services:
 
   stats:
     <<: [*default-logging, *default-restart]
-    image: vanaorg/stats-client:latest
+    image: vanaorg/vana-stats-client:latest
     container_name: stats
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
-      - STATS_SERVER_URL=${STATS_SERVER_URL}
-      - INSTANCE_NAME=${INSTANCE_NAME}
-      - VALIDATOR_PUBLIC_KEY=${VALIDATOR_PUBLIC_KEY}
-      - EXECUTION_WS_ENDPOINT=ws://geth:${GETH_WS_PORT:-8546}
-      - BEACON_RPC_PROVIDER=http://beacon:${GRPC_GATEWAY_PORT:-3500}
-      - WS_SECRET=${WS_SECRET}
+      - NODE_NAME=${NODE_NAME}
+      - SERVICE_URL=${STATS_SERVICE_URL}
+      - BEACON_ENDPOINT=http://beacon:${GRPC_GATEWAY_PORT:-3500}
+      - EXECUTION_ENDPOINT=ws://geth:${GETH_WS_PORT:-8546}
+      - VALIDATOR_PUBLIC_KEYS=${VALIDATOR_PUBLIC_KEYS}
+      - API_KEY=${STATS_API_KEY}
+      - LOG_LEVEL=${STATS_LOG_LEVEL:-"info"}
     profiles:
       - node
       - validator

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -641,7 +641,6 @@ services:
     profiles:
       - node
       - validator
-      - monitoring
 
   caddy:
     <<: [*default-logging, *default-restart]
@@ -667,7 +666,9 @@ services:
         condition: service_started
       beacon:
         condition: service_started
-    profiles: ["node", "validator"]
+    profiles:
+      - node
+      - validator
 
 secrets:
   deposit_private_key:


### PR DESCRIPTION
This updates the `stats` container to use the newest version of `vanaorg/vana-stats-client` instead of the older stats client, `vanaorg/stats-client`.