### PR TITLE
fix: point stats client at the chain data filesystem

### DIFF
--- a/.env.mainnet.example
+++ b/.env.mainnet.example
@@ -77,5 +77,7 @@ VALIDATOR_PUBLIC_KEYS= # The public keys of all validators running on this node,
 STATS_LOG_LEVEL=info # The log level for the stats service, e.g. "info", "debug", "error", "warn"
 
 # Host path on the filesystem holding chain data. Reported as this node's
-# disk usage. Set to / if everything is on one partition.
-DISK_CHECK_HOST_PATH=/mnt/vana
+# disk usage. Leave as / if chain data is on the root filesystem. If you keep
+# chain data on a separate disk, set this to a path on that disk (e.g.
+# /mnt/vana) or the reported disk usage will be for the boot disk instead.
+DISK_CHECK_HOST_PATH=/

--- a/.env.mainnet.example
+++ b/.env.mainnet.example
@@ -75,3 +75,7 @@ STATS_API_KEY= # Your API key for the stats service, if you have one
 NODE_NAME="Example Node" # A user-friendly name for your node
 VALIDATOR_PUBLIC_KEYS= # The public keys of all validators running on this node, e.g. 0x123...,0x456...,0x789...
 STATS_LOG_LEVEL=info # The log level for the stats service, e.g. "info", "debug", "error", "warn"
+
+# Host path on the filesystem holding chain data. Reported as this node's
+# disk usage. Set to / if everything is on one partition.
+DISK_CHECK_HOST_PATH=/mnt/vana

--- a/.env.moksha.example
+++ b/.env.moksha.example
@@ -73,5 +73,7 @@ INSTANCE_NAME="Example Validator"
 VALIDATOR_PUBLIC_KEY=0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000  # The public key of your validator
 
 # Host path on the filesystem holding chain data. Reported as this node's
-# disk usage. Set to / if everything is on one partition.
-DISK_CHECK_HOST_PATH=/mnt/vana
+# disk usage. Leave as / if chain data is on the root filesystem. If you keep
+# chain data on a separate disk, set this to a path on that disk (e.g.
+# /mnt/vana) or the reported disk usage will be for the boot disk instead.
+DISK_CHECK_HOST_PATH=/

--- a/.env.moksha.example
+++ b/.env.moksha.example
@@ -71,3 +71,7 @@ WEAK_SUBJECTIVITY_CHECKPOINT=0x0000000000000000000000000000000000000000000000000
 STATS_SERVER_URL=http://stats.moksha.vana.org
 INSTANCE_NAME="Example Validator"
 VALIDATOR_PUBLIC_KEY=0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000  # The public key of your validator
+
+# Host path on the filesystem holding chain data. Reported as this node's
+# disk usage. Set to / if everything is on one partition.
+DISK_CHECK_HOST_PATH=/mnt/vana

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -638,7 +638,12 @@ services:
     container_name: stats
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      # Chain data filesystem, read-only. Without this the stats client can
+      # only see the container overlay and reports the boot disk, so free
+      # space looks healthy while the data disk fills up.
+      - ${DISK_CHECK_HOST_PATH:-/}:/hostdisk:ro
     environment:
+      - DISK_CHECK_PATH=/hostdisk
       - NODE_NAME=${NODE_NAME}
       - SERVICE_URL=${STATS_SERVICE_URL}
       - BEACON_ENDPOINT=http://beacon:${GRPC_GATEWAY_PORT:-3500}


### PR DESCRIPTION
## Problem

The stats client reports the **boot disk**, not the disk holding chain data.

It calls `disk.check('/')`, and its container mounts only `docker.sock` — so `/` is the container overlay, backed by the boot disk. That was correct when chaindata shared the root filesystem. Once nodes moved chaindata to a second disk, the boot disk stayed nearly empty while the data disk filled, and the reported number stopped meaning anything.

Measured on a mainnet validator today:

| stats client reports | reality |
|---|---|
| 20G, 53% used | 492G, **61%** used on `/mnt/vana` |

Another node in the same fleet is at **96%** on its data disk with 22G free. The DataDog monitor (alert at 95%) never fired, because it is watching a disk that does not fill.

## Change

Mounts the chain-data filesystem read-only into the stats container and points the client at it.

- `DISK_CHECK_HOST_PATH` defaults to `/`, so operators on a single filesystem see no change.
- Added to both env examples with `/mnt/vana`, matching the layout the deployment docs describe.

Requires vana-com/vana-stats-client#12, which adds the `DISK_CHECK_PATH` variable. The mount alone is not enough — the client would still stat `/`.

## Rollout

Operators need a new stats-client image **and** this compose change. Worth an operator notification like BUI-94 (MEXC, Binance, Bybit, Upbit, Contango, Luganodes, QuickNode, Chainstack).

Refs PRO-357, PRO-686

Assisted-by: AI
