### PR TITLE
docs: add OpenChainBench live RPC latency benchmark link

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ The API gateway implements the following access controls:
 - Public endpoints:
   - Execution layer: All JSON-RPC endpoints (POST /)
   - Consensus layer: Limited set of beacon endpoints including genesis, headers, validator info, and node status
+  - [OpenChainBench](https://openchainbench.com/benchmarks/vana-rpc) — live p50/p90/p99 latency leaderboard for free Vana RPC endpoints, updated every 60 s
 - Private endpoints (localhost and trusted IPs only):
   - All other consensus layer endpoints under /eth/*
   - Configure trusted IPs via RPC_TRUSTED_IP_RANGES in .env


### PR DESCRIPTION
Adds a reference to [OpenChainBench](https://openchainbench.com/benchmarks/vana-rpc) in the API Access Control section under public endpoints.

OpenChainBench continuously probes free public Vana RPC endpoints and publishes independent p50/p90/p99 latency measurements updated every 60 seconds. Useful for node operators and developers choosing or verifying an RPC endpoint.