### PR TITLE
ci(hooks): resolve the policy cache from a worktree and harden the origin check

### DIFF
--- a/.github/scripts/install-evm-key-scan-hook.sh
+++ b/.github/scripts/install-evm-key-scan-hook.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 readonly CENTRAL_REPOSITORY='https://github.com/vana-com/.github.git'
-readonly CENTRAL_POLICY_SHA='5f1b4b1019af6e3a528dd36d471f94be7dd83632'
+readonly CENTRAL_POLICY_SHA='99904520ef5b18f1fceb0331b4d0b0fb182d0b62'
 
 action=${1:-install}
 case "$action" in
@@ -27,6 +27,38 @@ policy_dir="$cache_root/$CENTRAL_POLICY_SHA"
 lock_dir="$cache_root/.${CENTRAL_POLICY_SHA}.lock"
 tmp_dir=''
 
+# Git exports GIT_DIR (and friends) into hook processes. In a linked worktree
+# that value is an ABSOLUTE path, so a plain `policy_git -C "$policy_dir" ...` still
+# resolves against the pushing repository and reports ITS remote, HEAD and
+# status instead of the policy cache's — validation then rejects a perfectly
+# good cache with "unexpected policy-cache origin". (In a normal checkout
+# GIT_DIR is the relative ".git", which happens to resolve correctly under -C,
+# which is why this only bites worktrees.)
+#
+# The scrub list comes from git itself rather than a hardcoded set: it covers
+# the directory variables, the repository-local variables (GIT_SHALLOW_FILE,
+# GIT_GRAFT_FILE, GIT_REPLACE_REF_BASE, GIT_IMPLICIT_WORK_TREE) and
+# GIT_CONFIG_PARAMETERS / GIT_CONFIG_COUNT (which `git -c foo=bar push`
+# exports into hooks). The GIT_CONFIG_* FILE overrides are not in that list, so
+# they are added explicitly — without GIT_CONFIG_GLOBAL a caller can point
+# `remote.origin.url` at vana-com/.github from its own environment and satisfy
+# the origin check against a cache whose real origin is something else.
+# A hardcoded fallback covers a git too old to answer.
+policy_git() {
+  local scrub=()
+  local v
+  while IFS= read -r v; do
+    [[ -n "$v" ]] && scrub+=(-u "$v")
+  done < <(git rev-parse --local-env-vars 2>/dev/null || printf '%s\n' \
+    GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
+    GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR \
+    GIT_CONFIG GIT_CONFIG_PARAMETERS GIT_CONFIG_COUNT)
+  for v in GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM GIT_CONFIG_NOSYSTEM; do
+    scrub+=(-u "$v")
+  done
+  env "${scrub[@]}" git "$@"
+}
+
 cleanup() {
   [[ -z "$tmp_dir" ]] || rm -rf "$tmp_dir"
   rmdir "$lock_dir" 2>/dev/null || true
@@ -38,21 +70,21 @@ trap cleanup EXIT
 
 [[ ! -L "$policy_dir" ]] || fail "Refusing symlinked policy cache: $policy_dir"
 if [[ -d "$policy_dir/.git" ]]; then
-  origin=$(git -C "$policy_dir" remote get-url origin) || fail "Refusing unreadable policy cache: $policy_dir"
+  origin=$(policy_git -C "$policy_dir" remote get-url origin) || fail "Refusing unreadable policy cache: $policy_dir"
   case "$origin" in
     "$CENTRAL_REPOSITORY"|https://github.com/vana-com/.github|git@github.com:vana-com/.github|git@github.com:vana-com/.github.git) ;;
     *) fail "Refusing unexpected policy-cache origin: $policy_dir" ;;
   esac
-  [[ "$(git -C "$policy_dir" rev-parse HEAD)" == "$CENTRAL_POLICY_SHA" ]] || fail "Refusing stale policy cache: $policy_dir"
-  [[ -z "$(git -C "$policy_dir" status --porcelain --untracked-files=all -- ':!/.tools')" ]] || fail "Refusing modified policy cache: $policy_dir"
+  [[ "$(policy_git -C "$policy_dir" rev-parse HEAD)" == "$CENTRAL_POLICY_SHA" ]] || fail "Refusing stale policy cache: $policy_dir"
+  [[ -z "$(policy_git -C "$policy_dir" status --porcelain --untracked-files=all -- ':!/.tools')" ]] || fail "Refusing modified policy cache: $policy_dir"
 else
   [[ ! -e "$policy_dir" ]] || fail "Refusing invalid policy cache: $policy_dir"
   tmp_dir=$(mktemp -d "$cache_root/.policy.XXXXXX")
-  git init -q "$tmp_dir"
-  git -C "$tmp_dir" remote add origin "$CENTRAL_REPOSITORY"
-  git -C "$tmp_dir" fetch --depth 1 origin "$CENTRAL_POLICY_SHA"
-  git -C "$tmp_dir" checkout -q --detach FETCH_HEAD
-  [[ "$(git -C "$tmp_dir" rev-parse HEAD)" == "$CENTRAL_POLICY_SHA" ]] || fail 'Fetched policy does not match requested SHA.'
+  policy_git init -q "$tmp_dir"
+  policy_git -C "$tmp_dir" remote add origin "$CENTRAL_REPOSITORY"
+  policy_git -C "$tmp_dir" fetch --depth 1 origin "$CENTRAL_POLICY_SHA"
+  policy_git -C "$tmp_dir" checkout -q --detach FETCH_HEAD
+  [[ "$(policy_git -C "$tmp_dir" rev-parse HEAD)" == "$CENTRAL_POLICY_SHA" ]] || fail 'Fetched policy does not match requested SHA.'
   mv "$tmp_dir" "$policy_dir"
   tmp_dir=''
 fi

--- a/.github/workflows/evm-key-scan.yml
+++ b/.github/workflows/evm-key-scan.yml
@@ -8,4 +8,4 @@ permissions:
 
 jobs:
   evm-key-scan:
-    uses: vana-com/.github/.github/workflows/evm-key-scan.yml@5f1b4b1019af6e3a528dd36d471f94be7dd83632 # vana-com/.github#1
+    uses: vana-com/.github/.github/workflows/evm-key-scan.yml@99904520ef5b18f1fceb0331b4d0b0fb182d0b62 # vana-com/.github#2


### PR DESCRIPTION
The EVM key-scan bootstrap cannot pass from a git worktree, and its policy-cache origin check is satisfiable from the caller's environment. Both are fixed in the central policy (vana-com/.github#2) and in vana-sdk (vana-com/vana-sdk#189, merged); this applies the same fix here.

## Worktree bug

Git exports `GIT_DIR` into hook processes. In a linked worktree that value is an **absolute** path, so `git -C "$policy_dir" ...` still resolves against the pushing repository and reports ITS remote, HEAD and status instead of the policy cache's. Validation then rejects a perfectly good cache:

```
Refusing unexpected policy-cache origin: ~/.local/share/vana-secret-scan/policy/<sha>
```

In a normal checkout `GIT_DIR` is the relative `.git`, which happens to resolve correctly under `-C` — which is why this only bites worktrees. A hook that cannot pass is a hook developers route around with `--no-verify`, which is the outcome this policy exists to prevent.

## Origin check hardening

The scrub list is derived from `git rev-parse --local-env-vars` rather than hardcoded. Beyond the directory variables that fix the worktree bug, that covers the repository-local variables (`GIT_SHALLOW_FILE`, `GIT_GRAFT_FILE`, `GIT_REPLACE_REF_BASE`, `GIT_IMPLICIT_WORK_TREE`) and `GIT_CONFIG_PARAMETERS`/`GIT_CONFIG_COUNT`, which `git -c foo=bar push` exports into hooks.

`GIT_CONFIG_GLOBAL` is **not** in that list, so it is added explicitly. Without it, a caller can point `remote.origin.url` at `vana-com/.github` from its own environment and satisfy the origin check against a cache whose real origin is attacker-controlled. Verified on git 2.53.0: with the directory-only scrub the check returned the spoofed URL; with `GIT_CONFIG_GLOBAL` scrubbed it returns the real (attacker) URL and refuses.

The `git rev-parse --show-toplevel` that discovers the pushing repo deliberately keeps the inherited environment — that is exactly what it wants.

## Policy SHA bump

`CENTRAL_POLICY_SHA` moves to `9990452` (the merge of vana-com/.github#2). This is what makes the fix end-to-end: until the pinned policy contained the same fix, `install`/`status` would fail one layer later in the central scripts.

## Verification

Against the real merged policy, from a linked worktree with `GIT_DIR` set the way git sets it for hooks:

- **before**: `Refusing unexpected policy-cache origin`, nothing scanned
- **after**: validation passes and the policy cache is fetched at the pinned SHA
- **spoof test**: with the cache's origin set to `https://github.com/attacker/evil.git` and `GIT_CONFIG_GLOBAL` claiming `vana-com/.github`, this branch refuses at the origin check
- **detection unchanged**: verified in vana-sdk against the same policy — a range containing a key in a secret-shaped declaration still exits 1 with `Potential EVM private key detected`

This file is byte-identical across the five remaining repos, so the same patch applies to each.

Assisted-by: AI
