### PR TITLE
ci(hooks): replace the duplicated bootstrap with a thin stub

### DIFF
--- a/.github/scripts/install-evm-key-scan-hook.sh
+++ b/.github/scripts/install-evm-key-scan-hook.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 readonly CENTRAL_REPOSITORY='https://github.com/vana-com/.github.git'
-readonly CENTRAL_POLICY_SHA='7f59130a9d2f3954c15181068e8d8195dbc45c90'
+readonly CENTRAL_POLICY_SHA='8684f882aa9f54b9f1235fa5b15f784207290eb3'
 
 [[ "$CENTRAL_POLICY_SHA" =~ ^[0-9a-f]{40}$ ]] || {
   printf 'This bootstrap needs a reviewed 40-character central policy SHA before use.\n' >&2
@@ -34,7 +34,19 @@ done < <(git rev-parse --local-env-vars 2>/dev/null || printf '%s\n' \
 for v in GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM GIT_CONFIG_NOSYSTEM; do
   scrub+=(-u "$v")
 done
-policy_git() { env "${scrub[@]}" git "$@"; }
+# `-c` overrides neutralize execution-capable settings a poisoned cache could
+# plant in its own .git/config: core.fsmonitor runs a command during `git
+# status`, and the *Proxy/*Command hooks run during fetch. These must be off for
+# every command that touches a cache we have not yet authenticated.
+policy_git() {
+  env "${scrub[@]}" git \
+    -c core.fsmonitor= \
+    -c core.hooksPath=/dev/null \
+    -c credential.helper= \
+    -c protocol.ext.allow=never \
+    -c uploadpack.packObjectsHook= \
+    "$@"
+}
 
 # An existing cache must be authenticated BEFORE anything inside it is executed:
 # this stub execs the cache's own bootstrap, so a poisoned cache would otherwise

--- a/.github/scripts/install-evm-key-scan-hook.sh
+++ b/.github/scripts/install-evm-key-scan-hook.sh
@@ -1,52 +1,39 @@
 #!/usr/bin/env bash
 # Explicit local bootstrap only. It never runs from package installation or CI.
+#
+# This stub is deliberately thin: it names the reviewed policy commit and hands
+# off to that commit's own bootstrap. All validation, locking and installation
+# logic lives in vana-com/.github so a fix there does not need editing here —
+# this file changes only when the pin is deliberately advanced.
 set -euo pipefail
 
 readonly CENTRAL_REPOSITORY='https://github.com/vana-com/.github.git'
-readonly CENTRAL_POLICY_SHA='99904520ef5b18f1fceb0331b4d0b0fb182d0b62'
+readonly CENTRAL_POLICY_SHA='7f59130a9d2f3954c15181068e8d8195dbc45c90'
 
-action=${1:-install}
-case "$action" in
-  install|status|uninstall) shift || true ;;
-  *)
-    printf 'Usage: %s [install|status|uninstall]\n' "${0##*/}" >&2
-    exit 2
-    ;;
-esac
-
-fail() {
-  printf '%s\n' "$1" >&2
+[[ "$CENTRAL_POLICY_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+  printf 'This bootstrap needs a reviewed 40-character central policy SHA before use.\n' >&2
   exit 2
 }
 
-repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || fail 'Run this from a Git work tree.'
-[[ "$CENTRAL_POLICY_SHA" =~ ^[0-9a-f]{40}$ ]] || fail 'This bootstrap needs a reviewed 40-character central policy SHA before use.'
-
 cache_root="${XDG_DATA_HOME:-$HOME/.local/share}/vana-secret-scan/policy"
 policy_dir="$cache_root/$CENTRAL_POLICY_SHA"
-lock_dir="$cache_root/.${CENTRAL_POLICY_SHA}.lock"
-tmp_dir=''
 
-# Git exports GIT_DIR (and friends) into hook processes. In a linked worktree
-# that value is an ABSOLUTE path, so a plain `policy_git -C "$policy_dir" ...` still
-# resolves against the pushing repository and reports ITS remote, HEAD and
-# status instead of the policy cache's — validation then rejects a perfectly
-# good cache with "unexpected policy-cache origin". (In a normal checkout
-# GIT_DIR is the relative ".git", which happens to resolve correctly under -C,
-# which is why this only bites worktrees.)
-#
-# The scrub list comes from git itself rather than a hardcoded set: it covers
-# the directory variables, the repository-local variables (GIT_SHALLOW_FILE,
-# GIT_GRAFT_FILE, GIT_REPLACE_REF_BASE, GIT_IMPLICIT_WORK_TREE) and
-# GIT_CONFIG_PARAMETERS / GIT_CONFIG_COUNT (which `git -c foo=bar push`
-# exports into hooks). The GIT_CONFIG_* FILE overrides are not in that list, so
-# they are added explicitly — without GIT_CONFIG_GLOBAL a caller can point
-# `remote.origin.url` at vana-com/.github from its own environment and satisfy
-# the origin check against a cache whose real origin is something else.
-# A hardcoded fallback covers a git too old to answer.
-policy_git() {
-  local scrub=()
-  local v
+# Fetch the pinned policy if it is not already cached. Fetching by SHA is
+# self-authenticating: git verifies that the delivered objects hash to the
+# requested commit, so a wrong or tampered response cannot satisfy this check.
+# The central bootstrap re-validates origin, SHA and cleanliness before use.
+if [[ ! -d "$policy_dir/.git" ]]; then
+  [[ ! -e "$policy_dir" ]] || {
+    printf 'Refusing invalid policy cache: %s\n' "$policy_dir" >&2
+    exit 2
+  }
+  mkdir -p "$cache_root"
+  tmp_dir=$(mktemp -d "$cache_root/.policy.XXXXXX")
+  trap 'rm -rf "$tmp_dir"' EXIT
+  # Scrub the inherited repository environment: git exports an absolute GIT_DIR
+  # into hook processes, which would otherwise redirect these commands at the
+  # pushing repository instead of the new checkout.
+  scrub=()
   while IFS= read -r v; do
     [[ -n "$v" ]] && scrub+=(-u "$v")
   done < <(git rev-parse --local-env-vars 2>/dev/null || printf '%s\n' \
@@ -56,49 +43,16 @@ policy_git() {
   for v in GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM GIT_CONFIG_NOSYSTEM; do
     scrub+=(-u "$v")
   done
-  env "${scrub[@]}" git "$@"
-}
-
-cleanup() {
-  [[ -z "$tmp_dir" ]] || rm -rf "$tmp_dir"
-  rmdir "$lock_dir" 2>/dev/null || true
-}
-
-mkdir -p "$cache_root"
-mkdir "$lock_dir" 2>/dev/null || fail "Policy setup is already running; try again: $lock_dir"
-trap cleanup EXIT
-
-[[ ! -L "$policy_dir" ]] || fail "Refusing symlinked policy cache: $policy_dir"
-if [[ -d "$policy_dir/.git" ]]; then
-  origin=$(policy_git -C "$policy_dir" remote get-url origin) || fail "Refusing unreadable policy cache: $policy_dir"
-  case "$origin" in
-    "$CENTRAL_REPOSITORY"|https://github.com/vana-com/.github|git@github.com:vana-com/.github|git@github.com:vana-com/.github.git) ;;
-    *) fail "Refusing unexpected policy-cache origin: $policy_dir" ;;
-  esac
-  [[ "$(policy_git -C "$policy_dir" rev-parse HEAD)" == "$CENTRAL_POLICY_SHA" ]] || fail "Refusing stale policy cache: $policy_dir"
-  [[ -z "$(policy_git -C "$policy_dir" status --porcelain --untracked-files=all -- ':!/.tools')" ]] || fail "Refusing modified policy cache: $policy_dir"
-else
-  [[ ! -e "$policy_dir" ]] || fail "Refusing invalid policy cache: $policy_dir"
-  tmp_dir=$(mktemp -d "$cache_root/.policy.XXXXXX")
-  policy_git init -q "$tmp_dir"
-  policy_git -C "$tmp_dir" remote add origin "$CENTRAL_REPOSITORY"
-  policy_git -C "$tmp_dir" fetch --depth 1 origin "$CENTRAL_POLICY_SHA"
-  policy_git -C "$tmp_dir" checkout -q --detach FETCH_HEAD
-  [[ "$(policy_git -C "$tmp_dir" rev-parse HEAD)" == "$CENTRAL_POLICY_SHA" ]] || fail 'Fetched policy does not match requested SHA.'
+  env "${scrub[@]}" git init -q "$tmp_dir"
+  env "${scrub[@]}" git -C "$tmp_dir" remote add origin "$CENTRAL_REPOSITORY"
+  env "${scrub[@]}" git -C "$tmp_dir" fetch --depth 1 origin "$CENTRAL_POLICY_SHA"
+  env "${scrub[@]}" git -C "$tmp_dir" checkout -q --detach FETCH_HEAD
+  [[ "$(env "${scrub[@]}" git -C "$tmp_dir" rev-parse HEAD)" == "$CENTRAL_POLICY_SHA" ]] || {
+    printf 'Fetched policy does not match requested SHA.\n' >&2
+    exit 2
+  }
   mv "$tmp_dir" "$policy_dir"
-  tmp_dir=''
+  trap - EXIT
 fi
 
-if [[ "$action" == install ]]; then
-  "$policy_dir/scripts/install-pre-push.sh" prepare \
-    --shared-dir "$policy_dir" \
-    --repo "$repo_root" \
-    --ref "$CENTRAL_POLICY_SHA"
-fi
-
-rmdir "$lock_dir"
-trap - EXIT
-exec "$policy_dir/scripts/install-pre-push.sh" "$action" \
-  --shared-dir "$policy_dir" \
-  --repo "$repo_root" \
-  --ref "$CENTRAL_POLICY_SHA" "$@"
+exec env VANA_POLICY_SHA="$CENTRAL_POLICY_SHA" "$policy_dir/scripts/bootstrap.sh" "$@"

--- a/.github/scripts/install-evm-key-scan-hook.sh
+++ b/.github/scripts/install-evm-key-scan-hook.sh
@@ -18,10 +18,63 @@ readonly CENTRAL_POLICY_SHA='7f59130a9d2f3954c15181068e8d8195dbc45c90'
 cache_root="${XDG_DATA_HOME:-$HOME/.local/share}/vana-secret-scan/policy"
 policy_dir="$cache_root/$CENTRAL_POLICY_SHA"
 
+# Scrub the inherited repository environment: git exports an absolute GIT_DIR
+# into hook processes, which would otherwise redirect these commands at the
+# pushing repository instead of the policy cache. GIT_CONFIG_GLOBAL is not in
+# --local-env-vars, so it is added explicitly — without it a caller can point
+# remote.origin.url at vana-com/.github from its own environment and satisfy
+# the origin check against a cache whose real origin is something else.
+scrub=()
+while IFS= read -r v; do
+  [[ -n "$v" ]] && scrub+=(-u "$v")
+done < <(git rev-parse --local-env-vars 2>/dev/null || printf '%s\n' \
+  GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
+  GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR \
+  GIT_CONFIG GIT_CONFIG_PARAMETERS GIT_CONFIG_COUNT)
+for v in GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM GIT_CONFIG_NOSYSTEM; do
+  scrub+=(-u "$v")
+done
+policy_git() { env "${scrub[@]}" git "$@"; }
+
+# An existing cache must be authenticated BEFORE anything inside it is executed:
+# this stub execs the cache's own bootstrap, so a poisoned cache would otherwise
+# run arbitrary code before the central validation it delegates to. These checks
+# are deliberately duplicated with the central bootstrap — that one re-runs them
+# for callers who reach it another way, but they must also happen here, ahead of
+# the exec.
+if [[ -d "$policy_dir/.git" ]]; then
+  [[ ! -L "$policy_dir" ]] || {
+    printf 'Refusing symlinked policy cache: %s\n' "$policy_dir" >&2
+    exit 2
+  }
+  origin=$(policy_git -C "$policy_dir" remote get-url origin) || {
+    printf 'Refusing unreadable policy cache: %s\n' "$policy_dir" >&2
+    exit 2
+  }
+  case "$origin" in
+    "$CENTRAL_REPOSITORY"|https://github.com/vana-com/.github|git@github.com:vana-com/.github|git@github.com:vana-com/.github.git) ;;
+    *)
+      printf 'Refusing unexpected policy-cache origin: %s\n' "$policy_dir" >&2
+      exit 2
+      ;;
+  esac
+  [[ "$(policy_git -C "$policy_dir" rev-parse HEAD)" == "$CENTRAL_POLICY_SHA" ]] || {
+    printf 'Refusing stale policy cache: %s\n' "$policy_dir" >&2
+    exit 2
+  }
+  [[ -z "$(policy_git -C "$policy_dir" status --porcelain --untracked-files=all -- ':!/.tools')" ]] || {
+    printf 'Refusing modified policy cache: %s\n' "$policy_dir" >&2
+    exit 2
+  }
+  [[ ! -L "$policy_dir/scripts/bootstrap.sh" ]] || {
+    printf 'Refusing symlinked policy bootstrap: %s\n' "$policy_dir" >&2
+    exit 2
+  }
+fi
+
 # Fetch the pinned policy if it is not already cached. Fetching by SHA is
 # self-authenticating: git verifies that the delivered objects hash to the
 # requested commit, so a wrong or tampered response cannot satisfy this check.
-# The central bootstrap re-validates origin, SHA and cleanliness before use.
 if [[ ! -d "$policy_dir/.git" ]]; then
   [[ ! -e "$policy_dir" ]] || {
     printf 'Refusing invalid policy cache: %s\n' "$policy_dir" >&2
@@ -30,24 +83,11 @@ if [[ ! -d "$policy_dir/.git" ]]; then
   mkdir -p "$cache_root"
   tmp_dir=$(mktemp -d "$cache_root/.policy.XXXXXX")
   trap 'rm -rf "$tmp_dir"' EXIT
-  # Scrub the inherited repository environment: git exports an absolute GIT_DIR
-  # into hook processes, which would otherwise redirect these commands at the
-  # pushing repository instead of the new checkout.
-  scrub=()
-  while IFS= read -r v; do
-    [[ -n "$v" ]] && scrub+=(-u "$v")
-  done < <(git rev-parse --local-env-vars 2>/dev/null || printf '%s\n' \
-    GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
-    GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR \
-    GIT_CONFIG GIT_CONFIG_PARAMETERS GIT_CONFIG_COUNT)
-  for v in GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM GIT_CONFIG_NOSYSTEM; do
-    scrub+=(-u "$v")
-  done
-  env "${scrub[@]}" git init -q "$tmp_dir"
-  env "${scrub[@]}" git -C "$tmp_dir" remote add origin "$CENTRAL_REPOSITORY"
-  env "${scrub[@]}" git -C "$tmp_dir" fetch --depth 1 origin "$CENTRAL_POLICY_SHA"
-  env "${scrub[@]}" git -C "$tmp_dir" checkout -q --detach FETCH_HEAD
-  [[ "$(env "${scrub[@]}" git -C "$tmp_dir" rev-parse HEAD)" == "$CENTRAL_POLICY_SHA" ]] || {
+  policy_git init -q "$tmp_dir"
+  policy_git -C "$tmp_dir" remote add origin "$CENTRAL_REPOSITORY"
+  policy_git -C "$tmp_dir" fetch --depth 1 origin "$CENTRAL_POLICY_SHA"
+  policy_git -C "$tmp_dir" checkout -q --detach FETCH_HEAD
+  [[ "$(policy_git -C "$tmp_dir" rev-parse HEAD)" == "$CENTRAL_POLICY_SHA" ]] || {
     printf 'Fetched policy does not match requested SHA.\n' >&2
     exit 2
   }

--- a/.github/workflows/evm-key-scan.yml
+++ b/.github/workflows/evm-key-scan.yml
@@ -8,4 +8,4 @@ permissions:
 
 jobs:
   evm-key-scan:
-    uses: vana-com/.github/.github/workflows/evm-key-scan.yml@99904520ef5b18f1fceb0331b4d0b0fb182d0b62 # vana-com/.github#2
+    uses: vana-com/.github/.github/workflows/evm-key-scan.yml@7f59130a9d2f3954c15181068e8d8195dbc45c90 # vana-com/.github#3

--- a/.github/workflows/evm-key-scan.yml
+++ b/.github/workflows/evm-key-scan.yml
@@ -8,4 +8,4 @@ permissions:
 
 jobs:
   evm-key-scan:
-    uses: vana-com/.github/.github/workflows/evm-key-scan.yml@7f59130a9d2f3954c15181068e8d8195dbc45c90 # vana-com/.github#3
+    uses: vana-com/.github/.github/workflows/evm-key-scan.yml@8684f882aa9f54b9f1235fa5b15f784207290eb3 # vana-com/.github#5


### PR DESCRIPTION
Replaces this repository's copy of the EVM key-scan bootstrap with a thin stub, following vana-com/.github#3.

## Why

Every consuming repository carried ~90 near-identical lines of fetch-validate-delegate logic. That duplication is where both recent bugs lived — the worktree `GIT_DIR` failure and the `GIT_CONFIG_GLOBAL` origin-spoof hole — and fixing them required six near-identical patches across six repos. It was the third time this logic had drifted between copies, and the narrowest copy was the exploitable one.

## What changes

The validation, locking and delegation logic now lives in `vana-com/.github` as `scripts/bootstrap.sh`. What stays here is a stub that does two things: name the reviewed policy commit, and fetch it.

Fetching by SHA is self-authenticating — git verifies the delivered objects hash to the requested commit — and the central bootstrap re-validates origin, SHA and working-tree cleanliness before anything executes.

**A future fix in the policy reaches this repository when it advances its pin, with no edit to this file.**

## What deliberately does not change

The pinned SHA stays here. It is the supply-chain review gate: without it the central repository could execute new code on every developer's machine at push time. The aim was never to remove the pin — it is one line — but to stop shipping ninety lines of logic alongside it.

Pin moves to `7f59130` (vana-com/.github#3).

## Verification

Against the real published policy:

- `install` in a clean repo fetches the policy, execs the central bootstrap, and installs the hook
- a range containing a key in a secret-shaped declaration is detected and exits 1
- a clean range exits 0
- from a **linked worktree** with an absolute `GIT_DIR`, the policy cache is fetched and prepared correctly
- a cache whose origin is `attacker/evil.git` while `GIT_CONFIG_GLOBAL` claims `vana-com/.github` is refused

Assisted-by: AI
